### PR TITLE
fix: 헤더 알림 부분 불필요한 파라미터 제거

### DIFF
--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -42,8 +42,8 @@ const Header = () => {
 
   // 알림 목록 가져오기 (알림 개수 확인용)
   const { data: notificationsResponse } = useMyNotificationsList(
-    { cursorId: null, size: 10 },
-    authToken,
+    { size: 10 },
+    authToken
   );
   const hasNotifications = (notificationsResponse?.totalCount || 0) > 0;
 


### PR DESCRIPTION
옵셔널 파라미터인 cursorId 제거 
헤더 컴포넌트에서는 알림 개수만 확인하기에 불필요